### PR TITLE
Lazy load widgets, sharedPackages

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,22 @@
       "@jupyter-widgets/base": {
         "bundled": false,
         "singleton": true
+      },
+      "d3-array": {
+        "bundled": true,
+        "singleton": false
+      },
+      "d3-geo": {
+        "bundled": true,
+        "singleton": false
+      },
+      "d3-scale": {
+        "bundled": true,
+        "singleton": false
+      },
+      "underscore": {
+        "bundled": true,
+        "singleton": false
       }
     }
   }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -47,6 +47,6 @@ function activateWidgetExtension(
   registry.registerWidget({
     name: MODULE_NAME,
     version: MODULE_VERSION,
-    exports: () => import('./widgets')
+    exports: () => import('./widgets'),
   });
 }

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -19,8 +19,6 @@ import { Widget } from '@phosphor/widgets';
 
 import { IJupyterWidgetRegistry } from '@jupyter-widgets/base';
 
-import * as widgetExports from './widgets';
-
 import { MODULE_NAME, MODULE_VERSION } from './version';
 
 const EXTENSION_ID = 'bqscales:plugin';
@@ -49,6 +47,6 @@ function activateWidgetExtension(
   registry.registerWidget({
     name: MODULE_NAME,
     version: MODULE_VERSION,
-    exports: widgetExports,
+    exports: () => import('./widgets')
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "declaration": true,
     "esModuleInterop": true,
     "lib": ["es2015", "dom"],
-    "module": "commonjs",
+    "module": "esnext",
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
This ensures that the widget exports, and their relatively heavy dependencies, are not loaded until a widget is actually requested. 

Further, `sharedPackages` for the `d3` deps and `underscore` help ensure multiple copies aren't needlessly loaded.

See also: https://github.com/bqplot/bqplot/pull/1192